### PR TITLE
Documentation spelling fixes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,7 +119,7 @@ u'05 12 1987'
 >>> format_datetime(datetime(1987, 3, 5, 17, 12), 'dd mm yyyy')
 u'05 12 1987'
 
-And again with a different langauge:
+And again with a different language:
 
 >>> app.config['BABEL_DEFAULT_LOCALE'] = 'de'
 >>> from flaskext.babel import refresh; refresh()

--- a/flaskext/babel.py
+++ b/flaskext/babel.py
@@ -164,7 +164,7 @@ class Babel(object):
 
 def get_translations():
     """Returns the correct gettext translations that should be used for
-    ths request.  This will never fail and return a dummy translation
+    this request.  This will never fail and return a dummy translation
     object if used outside of the request or if a translation cannot be
     found.
     """


### PR DESCRIPTION
Here are a couple of spelling fixes for documentation.

I would also reword the last sentence of the docstring for the `flaskext.babel.refresh()` method — can't be understood IMHO.
