### PR TITLE
gae-pytz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.egg-info
 dist/
 docs/_build
+*.swp
+*.un~

--- a/flaskext/babel.py
+++ b/flaskext/babel.py
@@ -19,8 +19,14 @@ if os.environ.get('LC_CTYPE', '').lower() == 'utf-8':
 from datetime import datetime
 from flask import _request_ctx_stack
 from babel import dates, support, Locale
-from pytz import timezone, UTC
 from werkzeug import ImmutableDict
+try:
+    from pytz.gae import pytz
+except ImportError:
+    from pytz import timezone, UTC
+else:
+    timezone = pytz.timezone
+    UTC = pytz.UTC
 
 
 class Babel(object):


### PR DESCRIPTION
I'm using flask-babel in an App Engine app and patched it to try using gae-pytz before falling back on unpatched pytz. Not sure if this is appropriate to be pulled back into your repo or if it should stay in my fork, but I'm making the pull request just in case.

Thanks, Armin!
