### PR TITLE
Only return compiled locales or the default one.

### DIFF
--- a/flaskext/babel.py
+++ b/flaskext/babel.py
@@ -149,8 +149,13 @@ class Babel(object):
             return []
         result = []
         for folder in os.listdir(dirname):
-            if os.path.isdir(os.path.join(dirname, folder, 'LC_MESSAGES')):
+            locale_dir = os.path.join(dirname, folder, 'LC_MESSAGES')
+            if not os.path.isdir(locale_dir):
+                continue
+            if filter(lambda x: x.endswith('.mo'), os.listdir(locale_dir)):
                 result.append(Locale.parse(folder))
+        if not result:
+            result.append(Locale.parse(self._default_locale))
         return result
 
     @property


### PR DESCRIPTION
Only return compiled locales, in case there isn't any, return the `default_locale`.
