### PR TITLE
do not hardcode the translations folder path

### DIFF
--- a/flaskext/babel.py
+++ b/flaskext/babel.py
@@ -54,12 +54,18 @@ class Babel(object):
         'datetime.long':    None,
     })
 
-    def __init__(self, app=None, default_locale='en', default_timezone='UTC',
-                 date_formats=None, configure_jinja=True):
+    def __init__(self,
+                 app=None,
+                 default_locale='en',
+                 default_timezone='UTC',
+                 date_formats=None,
+                 configure_jinja=True,
+                 folder='translations'):
         self._default_locale = default_locale
         self._default_timezone = default_timezone
         self._date_formats = date_formats
         self._configure_jinja = configure_jinja
+        self._folder = folder
         self.app = app
 
         if app is not None:
@@ -77,6 +83,7 @@ class Babel(object):
 
         app.config.setdefault('BABEL_DEFAULT_LOCALE', self._default_locale)
         app.config.setdefault('BABEL_DEFAULT_TIMEZONE', self._default_timezone)
+        app.config.setdefault('BABEL_TRANSLATIONS_FOLDER', self._folder)
         if self._date_formats is None:
             self._date_formats = self.default_date_formats.copy()
 
@@ -150,7 +157,11 @@ class Babel(object):
 
         .. versionadded:: 0.6
         """
-        dirname = os.path.join(self.app.root_path, 'translations')
+        dirname = os.path.join(
+            self.app.root_path,
+            self.app.config['BABEL_TRANSLATIONS_FOLDER']
+        )
+
         if not os.path.isdir(dirname):
             return []
         result = []
@@ -190,7 +201,10 @@ def get_translations():
         return None
     translations = getattr(ctx, 'babel_translations', None)
     if translations is None:
-        dirname = os.path.join(ctx.app.root_path, 'translations')
+        dirname = os.path.join(
+            ctx.app.root_path,
+            ctx.app.config['BABEL_TRANSLATIONS_FOLDER']
+        )
         translations = support.Translations.load(dirname, [get_locale()])
         ctx.babel_translations = translations
     return translations


### PR DESCRIPTION
This allows to specify in which folder the translations should be looked for instead of having it hardcoded (still defaults to "translations").
This is done either via a `folder` param passed to the constructor or via the `BABEL_TRANSLATIONS_FOLDER` configuration variable.