### PR TITLE
apply unicode() when gettext()(or ngettext()) received string argument and translations have it's own charset.

### DIFF
--- a/flaskext/babel.py
+++ b/flaskext/babel.py
@@ -116,7 +116,10 @@ class Babel(object):
                 charset = translations.charset() 
 
                 if charset:
-                    x = unicode(x, charset)
+                    try:
+                        x = unicode(x, charset)
+                    except TypeError:
+                        pass
                     
                 return translations.ugettext(x)
             
@@ -125,9 +128,12 @@ class Babel(object):
                 charset = translations.charset()
                 
                 if charset:
-                    s = unicode(s, charset)
-                    p = unicode(p, charset)
-                    n = unicode(n, charset)
+                    try:
+                        s = unicode(s, charset)
+                        p = unicode(p, charset)
+                        n = unicode(n, charset)
+                    except TypeError:
+                        pass
                     
                 return translations.ungettext(s, p, n)
             


### PR DESCRIPTION
If target translations contain own charset(ex. utf-8),  <code>GNUTranslations</code> convert it's key to unicode. 

``` python
# gettext.py

def _parse(self, fp):
# ...
            if '\x00' in msg:
                # Plural forms
                msgid1, msgid2 = msg.split('\x00')
                tmsg = tmsg.split('\x00')
                if self._charset:
                    msgid1 = unicode(msgid1, self._charset)
                    tmsg = [unicode(x, self._charset) for x in tmsg]
                for i in range(len(tmsg)):
                    catalog[(msgid1, i)] = tmsg[i]
            else:
                if self._charset:
                    msg = unicode(msg, self._charset)
                    tmsg = unicode(tmsg, self._charset)
                catalog[msg] = tmsg
```

I can't access them via flask-babel's <code>_()</code> in jinja2 because argument of that is utf-8 encoded string, not unicode. so I changed <code>init_app()</code> to install different version of functions to <code>app.jinja_env</code>.

Please check and comment if it's not necessary. thanks.
