### PR TITLE
Fix the tests running on Babel==1.0

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -21,13 +21,13 @@ class DateFormattingTestCase(unittest.TestCase):
         d = datetime(2010, 4, 12, 13, 46)
 
         with app.test_request_context():
-            assert babel.format_datetime(d) == 'Apr 12, 2010 1:46:00 PM'
+            assert babel.format_datetime(d) == 'Apr 12, 2010, 1:46:00 PM'
             assert babel.format_date(d) == 'Apr 12, 2010'
             assert babel.format_time(d) == '1:46:00 PM'
 
         with app.test_request_context():
             app.config['BABEL_DEFAULT_TIMEZONE'] = 'Europe/Vienna'
-            assert babel.format_datetime(d) == 'Apr 12, 2010 3:46:00 PM'
+            assert babel.format_datetime(d) == 'Apr 12, 2010, 3:46:00 PM'
             assert babel.format_date(d) == 'Apr 12, 2010'
             assert babel.format_time(d) == '3:46:00 PM'
 
@@ -43,13 +43,13 @@ class DateFormattingTestCase(unittest.TestCase):
         d = datetime(2010, 4, 12, 13, 46)
 
         with app.test_request_context():
-            assert babel.format_datetime(d) == 'Apr 12, 2010 1:46:00 PM'
+            assert babel.format_datetime(d) == 'Apr 12, 2010, 1:46:00 PM'
             assert babel.format_date(d) == 'Apr 12, 2010'
             assert babel.format_time(d) == '1:46:00 PM'
 
         with app.test_request_context():
             app.config['BABEL_DEFAULT_TIMEZONE'] = 'Europe/Vienna'
-            assert babel.format_datetime(d) == 'Apr 12, 2010 3:46:00 PM'
+            assert babel.format_datetime(d) == 'Apr 12, 2010, 3:46:00 PM'
             assert babel.format_date(d) == 'Apr 12, 2010'
             assert babel.format_time(d) == '3:46:00 PM'
 
@@ -88,7 +88,7 @@ class DateFormattingTestCase(unittest.TestCase):
             return the_timezone
 
         with app.test_request_context():
-            assert babel.format_datetime(d) == 'Apr 12, 2010 1:46:00 PM'
+            assert babel.format_datetime(d) == 'Apr 12, 2010, 1:46:00 PM'
 
         the_locale = 'de_DE'
         the_timezone = 'Europe/Vienna'
@@ -101,10 +101,10 @@ class DateFormattingTestCase(unittest.TestCase):
         b = babel.Babel(app)
         d = datetime(2010, 4, 12, 13, 46)
         with app.test_request_context():
-            assert babel.format_datetime(d) == 'Apr 12, 2010 1:46:00 PM'
+            assert babel.format_datetime(d) == 'Apr 12, 2010, 1:46:00 PM'
             app.config['BABEL_DEFAULT_TIMEZONE'] = 'Europe/Vienna'
             babel.refresh()
-            assert babel.format_datetime(d) == 'Apr 12, 2010 3:46:00 PM'
+            assert babel.format_datetime(d) == 'Apr 12, 2010, 3:46:00 PM'
 
 
 class NumberFormattingTestCase(unittest.TestCase):


### PR DESCRIPTION
The datetime format has slightly changed with Babel 1.0 which causes several test failures. This PR fixes those failures (while introducing ones if the tests are run on earlier versions.)
