### PR TITLE
Fix delayed init_app for *selector decorators

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -62,6 +62,8 @@ class Babel(object):
         self._default_timezone = default_timezone
         self._date_formats = date_formats
         self._configure_jinja = configure_jinja
+        self.locale_selector_func = None
+        self.timezone_selector_func = None
         self.app = app
 
         if app is not None:
@@ -94,9 +96,6 @@ class Babel(object):
         #:      is anything but `None` this is used as new format string.
         #:      otherwise the default for that language is used.
         self.date_formats = self._date_formats
-
-        self.locale_selector_func = None
-        self.timezone_selector_func = None
 
         if self._configure_jinja:
             app.jinja_env.filters.update(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -170,5 +170,25 @@ class GettextTestCase(unittest.TestCase):
         assert str(translations[0]) == 'de'
 
 
+class AppFactoryTestCase(unittest.TestCase):
+
+    def test_basics(self):
+        b = babel.Babel()
+        app = flask.Flask(__name__)
+        b.init_app(app)
+
+    def test_getter_decorators(self):
+        b = babel.Babel()
+        app = flask.Flask(__name__)
+
+        @b.localeselector
+        def get_locale():
+            return 'de_DE'
+
+        @b.timezoneselector
+        def get_timezone():
+            return 'Europe/Vienna'
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The current package breaks if you try to wrap locale or timezone selector functions with the respective `Babel.<whatever>selector` methods.

The issue is caused by [checking whether the functions are `None`](https://github.com/mitsuhiko/flask-babel/blob/master/flask_babel/__init__.py#L129) in the decorators. They are currently set to `None` in `init_app` and don't exist otherwise, so this fails with an `AttributeError` if the app has been instantiated, but not initialized (like `babel = Babel()`).

My pull pull request has a simple test that breaks with the current code, and a trivial fix to make it pass (move `self.*_selector = None` to `__init__` from `init_app`).

