### PR TITLE
add threshold arg to format_timedelta function

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -428,10 +428,9 @@ def format_time(time=None, format=None, rebase=True):
 
 
 def format_timedelta(datetime_or_timedelta, granularity='second',
-                     add_direction=False):
+                     add_direction=False, threshold=0.85):
     """Format the elapsed time from the given date to now or the given
-    timedelta.  This currently requires an unreleased development
-    version of Babel.
+    timedelta.
 
     This function is also available in the template context as filter
     named `timedeltaformat`.
@@ -441,6 +440,7 @@ def format_timedelta(datetime_or_timedelta, granularity='second',
     return dates.format_timedelta(
         datetime_or_timedelta,
         granularity,
+        threshold=threshold,
         add_direction=add_direction,
         locale=get_locale()
     )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,7 +10,7 @@ import pickle
 import unittest
 from decimal import Decimal
 import flask
-from datetime import datetime
+from datetime import datetime, timedelta
 import flask_babel as babel
 from flask_babel import gettext, ngettext, lazy_gettext, get_translations
 from babel.support import NullTranslations
@@ -76,11 +76,14 @@ class DateFormattingTestCase(unittest.TestCase):
         app = flask.Flask(__name__)
         babel.Babel(app)
         d = datetime(2010, 4, 12, 13, 46)
+        delta = timedelta(days=6)
 
         with app.test_request_context():
             assert babel.format_datetime(d) == 'Apr 12, 2010, 1:46:00 PM'
             assert babel.format_date(d) == 'Apr 12, 2010'
             assert babel.format_time(d) == '1:46:00 PM'
+            assert babel.format_timedelta(delta) == '1 week'
+            assert babel.format_timedelta(delta, threshold=1) == '6 days'
 
         with app.test_request_context():
             app.config['BABEL_DEFAULT_TIMEZONE'] = 'Europe/Vienna'


### PR DESCRIPTION
Support for threshold argument to format_timedelta function. Additionally, the version of Babel containing this function has already been released.
