### PR TITLE
Moved selector attrs to the __init__ to support factory-based Flask app initialisation

### DIFF
--- a/flaskext/babel.py
+++ b/flaskext/babel.py
@@ -62,6 +62,9 @@ class Babel(object):
         self._configure_jinja = configure_jinja
         self.app = app
 
+        self.locale_selector_func = None
+        self.timezone_selector_func = None
+
         if app is not None:
             self.init_app(app)
 
@@ -92,9 +95,6 @@ class Babel(object):
         #:      is anything but `None` this is used as new format string.
         #:      otherwise the default for that language is used.
         self.date_formats = self._date_formats
-
-        self.locale_selector_func = None
-        self.timezone_selector_func = None
 
         if self._configure_jinja:
             app.jinja_env.filters.update(


### PR DESCRIPTION
Here is simple override of two attributes assign to support factory-based workaround introduced in [semirook/flask-kit](https://github.com/semirook/flask-kit) boilerplate