### PR TITLE
Add support for flask extension and Babel

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 import os
 
+
 # this is a workaround for a snow leopard bug that babel does not
 # work around :)
 if os.environ.get('LC_CTYPE', '').lower() == 'utf-8':

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -198,7 +198,7 @@ def get_translations():
         print "BABEL DIRNAME", dirname
         translations = support.Translations.load(dirname, [get_locale()])
         print "BEFORE TRANS", translations
-        if isinstance(translations, support.NullTranslations):
+        if not hasattr(translations, 'merge'):
             print "BABEL no translation found for APP"
             translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
         else:

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -196,6 +196,8 @@ def get_translations():
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
         translations.merge(support.Translations.load(self.pkg_translations.__path__[0], [get_locale()])
+        print dir(translations)
+        print "DIR PKG", self.pkg_translations.__path__[0]
         ctx.babel_translations = translations
     return translations
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -196,10 +196,11 @@ def get_translations():
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
         pkg_translations = ctx.app.extensions.get('babel').pkg_translations
-        if not hasattr(translations, 'merge'):
-            translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
-        else:
-            translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
+        if pkg_translations:
+            if not hasattr(translations, 'merge'):
+                translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
+            else:
+                translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
         ctx.babel_translations = translations
     return translations
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -198,7 +198,7 @@ def get_translations():
         print "BABEL DIRNAME", dirname
         translations = support.Translations.load(dirname, [get_locale()])
         print "BEFORE TRANS", translations
-        if not translations or isinstance(translations, support.NullTranslations):
+        if isinstance(translations, support.NullTranslations):
             print "BABEL no translation found for APP"
             translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
         else:

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -192,15 +192,14 @@ def get_translations():
     if ctx is None:
         return None
     translations = getattr(ctx, 'babel_translations', None)
-    pkg_translations = ctx.app.extensions.get('babel').pkg_translations
-    if translations is None:
+    if translations is None and hasattr(ctx.app.extensions.get('babel'), 'pkg_translations'):
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
-        if pkg_translations:
-            if not hasattr(translations, 'merge'):
-                translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
-            else:
-                translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
+        pkg_translations = ctx.app.extensions.get('babel').pkg_translations
+        if not hasattr(translations, 'merge'):
+            translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
+        else:
+            translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
         ctx.babel_translations = translations
     return translations
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -195,6 +195,7 @@ def get_translations():
     pkg_translations = ctx.app.extensions.get('babel').pkg_translations
     if translations is None:
         dirname = os.path.join(ctx.app.root_path, 'translations')
+        print "BABEL DIRNAME", dirname
         translations = support.Translations.load(dirname, [get_locale()])
         if not translations or isinstance(translations, support.NullTranslations):
             print "BABEL no translation found for APP"

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -165,6 +165,7 @@ class Babel(object):
                 result.append(Locale.parse(folder))
         if not result:
             result.append(Locale.parse(self._default_locale))
+        print "LIST TRANSLATIONS", result
         return result
 
     @property

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -197,6 +197,7 @@ def get_translations():
         dirname = os.path.join(ctx.app.root_path, 'translations')
         print "BABEL DIRNAME", dirname
         translations = support.Translations.load(dirname, [get_locale()])
+        print "BEFORE TRANS", translations
         if not translations or isinstance(translations, support.NullTranslations):
             print "BABEL no translation found for APP"
             translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import
 import os
 
-
 # this is a workaround for a snow leopard bug that babel does not
 # work around :)
 if os.environ.get('LC_CTYPE', '').lower() == 'utf-8':

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -196,10 +196,11 @@ def get_translations():
     if translations is None:
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
-        if not hasattr(translations, 'merge'):
-            translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
-        else:
-            translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
+        if pkg_translations:
+            if not hasattr(translations, 'merge'):
+                translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
+            else:
+                translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
         ctx.babel_translations = translations
     return translations
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -165,7 +165,6 @@ class Babel(object):
                 result.append(Locale.parse(folder))
         if not result:
             result.append(Locale.parse(self._default_locale))
-        print "LIST TRANSLATIONS", result
         return result
 
     @property
@@ -201,8 +200,6 @@ def get_translations():
             translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
         else:
             translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
-        print dir(translations)
-        print "DIR PKG", pkg_translations.__path__[0]
         ctx.babel_translations = translations
     return translations
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -202,7 +202,7 @@ def get_translations():
         else:
             translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
         print dir(translations)
-        print "DIR PKG", self.pkg_translations.__path__[0]
+        print "DIR PKG", pkg_translations.__path__[0]
         ctx.babel_translations = translations
     return translations
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -56,7 +56,7 @@ class Babel(object):
         'datetime.long':    None,
     })
 
-    def __init__(self, app=None, default_locale='en', default_timezone='UTC',
+    def __init__(self, app=None, pkg_translations=None, default_locale='en', default_timezone='UTC',
                  date_formats=None, configure_jinja=True):
         self._default_locale = default_locale
         self._default_timezone = default_timezone
@@ -65,13 +65,14 @@ class Babel(object):
         self.app = app
 
         if app is not None:
-            self.init_app(app)
+            self.init_app(app, pkg_translations)
 
-    def init_app(self, app):
+    def init_app(self, app, pkg_translations=None):
         """Set up this instance for use with *app*, if no app was passed to
         the constructor.
         """
         self.app = app
+        self.pkg_translations = pkg_tranlations
         app.babel_instance = self
         if not hasattr(app, 'extensions'):
             app.extensions = {}
@@ -194,6 +195,7 @@ def get_translations():
     if translations is None:
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
+        translations.merge(support.Translations.load(self.pkg_translations.__path__[0], [get_locale()])
         ctx.babel_translations = translations
     return translations
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -195,7 +195,7 @@ def get_translations():
     if translations is None:
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
-        translations.merge(support.Translations.load(self.pkg_translations.__path__[0], [get_locale()])
+        translations.merge(support.Translations.load(self.pkg_translations.__path__[0], [get_locale()]))
         print dir(translations)
         print "DIR PKG", self.pkg_translations.__path__[0]
         ctx.babel_translations = translations

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -196,7 +196,10 @@ def get_translations():
     if translations is None:
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
-        translations.merge(support.Translations.load(self.pkg_translations.__path__[0], [get_locale()]))
+        if isinstance(translations, NullTranslations):
+            translations = support.Translations.load(self.pkg_translations.__path__[0], [get_locale()])
+        else:
+            translations.merge(support.Translations.load(self.pkg_translations.__path__[0], [get_locale()]))
         print dir(translations)
         print "DIR PKG", self.pkg_translations.__path__[0]
         ctx.babel_translations = translations

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -193,13 +193,14 @@ def get_translations():
     if ctx is None:
         return None
     translations = getattr(ctx, 'babel_translations', None)
+    pkg_translations = ctx.app.extensions.get('babel').pkg_translations
     if translations is None:
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
         if not translations or isinstance(translations, support.NullTranslations):
-            translations = support.Translations.load(self.pkg_translations.__path__[0], [get_locale()])
+            translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
         else:
-            translations.merge(support.Translations.load(self.pkg_translations.__path__[0], [get_locale()]))
+            translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
         print dir(translations)
         print "DIR PKG", self.pkg_translations.__path__[0]
         ctx.babel_translations = translations

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -196,7 +196,7 @@ def get_translations():
     if translations is None:
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
-        if isinstance(translations, NullTranslations):
+        if not translations or isinstance(translations, support.NullTranslations):
             translations = support.Translations.load(self.pkg_translations.__path__[0], [get_locale()])
         else:
             translations.merge(support.Translations.load(self.pkg_translations.__path__[0], [get_locale()]))

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -197,9 +197,12 @@ def get_translations():
         dirname = os.path.join(ctx.app.root_path, 'translations')
         translations = support.Translations.load(dirname, [get_locale()])
         if not translations or isinstance(translations, support.NullTranslations):
+            print "BABEL no translation found for APP"
             translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
         else:
+            print "BABEL MERGE"
             translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
+        print "TRANS", translations
         ctx.babel_translations = translations
     return translations
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -195,16 +195,11 @@ def get_translations():
     pkg_translations = ctx.app.extensions.get('babel').pkg_translations
     if translations is None:
         dirname = os.path.join(ctx.app.root_path, 'translations')
-        print "BABEL DIRNAME", dirname
         translations = support.Translations.load(dirname, [get_locale()])
-        print "BEFORE TRANS", translations
         if not hasattr(translations, 'merge'):
-            print "BABEL no translation found for APP"
             translations = support.Translations.load(pkg_translations.__path__[0], [get_locale()])
         else:
-            print "BABEL MERGE"
             translations.merge(support.Translations.load(pkg_translations.__path__[0], [get_locale()]))
-        print "TRANS", translations
         ctx.babel_translations = translations
     return translations
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -72,7 +72,7 @@ class Babel(object):
         the constructor.
         """
         self.app = app
-        self.pkg_translations = pkg_tranlations
+        self.pkg_translations = pkg_translations
         app.babel_instance = self
         if not hasattr(app, 'extensions'):
             app.extensions = {}

--- a/git_download.sh
+++ b/git_download.sh
@@ -1,0 +1,1 @@
+git pull origin master

--- a/git_upload.sh
+++ b/git_upload.sh
@@ -1,0 +1,20 @@
+git add LICENSE
+git add *.py -A
+git add *.in -A
+git add *.cfg -A
+git add *.sh -A
+git add *.mo -A
+git add *.po -A
+git add .gitignore
+git add *.md -A
+git add *.rst -A
+git add *.txt -A
+git add *.png -A
+git add ./flask_babel -A
+git add ./bin -A
+git add ./babel -A
+git add ./docs -A
+git add ./docs/_static -A
+git add ./examples -A
+git commit -m "$1"
+git push origin master


### PR DESCRIPTION
I'm using this fork on my flask.ext like this::

    from flask.ext.appbuilder import translations

    self.babel = Babel(app, translations)


flask-babel will merge the package translations with the app translations (if one exists). It would be great if you accept this on your project because i am already using it, and would preffer to use your "oficial" extension (has a requirement to my package) then my fork.