### PR TITLE
Error when not calling init_app() before setting @babel.localeselector

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/_themes"]
-	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -63,6 +63,8 @@ class Babel(object):
         self._date_formats = date_formats
         self._configure_jinja = configure_jinja
         self.app = app
+        self.locale_selector_func = None
+        self.timezone_selector_func = None
 
         if app is not None:
             self.init_app(app)
@@ -94,9 +96,6 @@ class Babel(object):
         #:      is anything but `None` this is used as new format string.
         #:      otherwise the default for that language is used.
         self.date_formats = self._date_formats
-
-        self.locale_selector_func = None
-        self.timezone_selector_func = None
 
         if self._configure_jinja:
             app.jinja_env.filters.update(


### PR DESCRIPTION
Setting a function to @babel.localeselector and @babel.timezoneselector shouldn't need the extension to be linked to the Flask app.

Moved setting of variables from the init_app() to the __init__().