### PR TITLE
Make list_translations return the correct default locale

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -163,7 +163,7 @@ class Babel(object):
             if filter(lambda x: x.endswith('.mo'), os.listdir(locale_dir)):
                 result.append(Locale.parse(folder))
         if not result:
-            result.append(Locale.parse(self._default_locale))
+            result.append(self.default_locale)
         return result
 
     @property


### PR DESCRIPTION
The current implementation ignore `BABEL_DEFAULT_LOCALE` and returns the `default_locale` passed to Babel.__init__ 
