### PR TITLE
Support temporary language switch inside a request

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -290,6 +290,8 @@ Low-Level API
 
 .. autofunction:: refresh
 
+.. autofunction:: force_locale
+
 
 .. _Flask: http://flask.pocoo.org/
 .. _babel: http://babel.edgewall.org/

--- a/flaskext/babel.py
+++ b/flaskext/babel.py
@@ -291,7 +291,7 @@ def force_locale(locale):
         yield
     finally:
         babel.locale_selector_func = orig_locale_selector_func
-        for key, value in orig_attrs.iteritems():
+        for key, value in orig_attrs.items():
             setattr(ctx, key, value)
 
 

--- a/flaskext/babel.py
+++ b/flaskext/babel.py
@@ -17,6 +17,7 @@ if os.environ.get('LC_CTYPE', '').lower() == 'utf-8':
     os.environ['LC_CTYPE'] = 'en_US.utf-8'
 
 from datetime import datetime
+from contextlib import contextmanager
 from flask import _request_ctx_stack
 from babel import dates, numbers, support, Locale
 from werkzeug import ImmutableDict
@@ -260,6 +261,38 @@ def refresh():
     for key in 'babel_locale', 'babel_tzinfo', 'babel_translations':
         if hasattr(ctx, key):
             delattr(ctx, key)
+
+
+@contextmanager
+def force_locale(locale):
+    """Temporarily overrides the currently selected locale.  Sometimes
+    it is useful to switch the current locale to different one, do
+    some tasks and then revert back to the original one. For example,
+    if the user uses German on the web site, but you want to send
+    them an email in English, you can use this function as a context
+    manager::
+
+        with force_locale('en_US'):
+            send_email(gettext('Hello!'), ...)
+    """
+    ctx = _request_ctx_stack.top
+    if ctx is None:
+        yield
+        return
+    babel = ctx.app.extensions['babel']
+    orig_locale_selector_func = babel.locale_selector_func
+    orig_attrs = {}
+    for key in ('babel_translations', 'babel_locale'):
+        orig_attrs[key] = getattr(ctx, key, None)
+    try:
+        babel.locale_selector_func = lambda: locale
+        for key in orig_attrs:
+            setattr(ctx, key, None)
+        yield
+    finally:
+        babel.locale_selector_func = orig_locale_selector_func
+        for key, value in orig_attrs.iteritems():
+            setattr(ctx, key, value)
 
 
 def _get_format(key, format):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -106,6 +106,20 @@ class DateFormattingTestCase(unittest.TestCase):
             babel.refresh()
             assert babel.format_datetime(d) == 'Apr 12, 2010 3:46:00 PM'
 
+    def test_force_locale(self):
+        app = flask.Flask(__name__)
+        b = babel.Babel(app)
+
+        @b.localeselector
+        def select_locale():
+            return 'de_DE'
+
+        with app.test_request_context():
+            assert str(babel.get_locale()) == 'de_DE'
+            with babel.force_locale('en_US'):
+                assert str(babel.get_locale()) == 'en_US'
+            assert str(babel.get_locale()) == 'de_DE'
+
 
 class NumberFormattingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
This is a change I have implemented three years ago (wow), but I realized I never submitted a pull request. Probably because my other pull request from 2012 was not merged, so I was a bit frustrated. :)

Anyway, I'm creating this pull request so that it's easier to find, if somebody wants to integrate it. This solves https://github.com/mitsuhiko/flask-babel/issues/2.