### PR TITLE
Babel 2.x breaks flask-babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Flask Babel
 ===========
 
-![Build Status](https://travis-ci.org/mitsuhiko/flask-babel.svg?branch=master)](https://travis-ci.org/mitsuhiko/flask-babel)
+[![Build Status](https://travis-ci.org/mitsuhiko/flask-babel.svg?branch=master)](https://travis-ci.org/mitsuhiko/flask-babel)
 
 Implements i18n and l10n support for Flask.  This is based on the Python
 babel module as well as pytz both of which are installed automatically

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 Flask Babel
+===========
+
+![Build Status](https://travis-ci.org/mitsuhiko/flask-babel.svg?branch=master)](https://travis-ci.org/mitsuhiko/flask-babel)
 
 Implements i18n and l10n support for Flask.  This is based on the Python
 babel module as well as pytz both of which are installed automatically

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask',
-        'Babel>=1.0',
+        'Babel>=1.0,<2.0',
         'speaklater>=1.2',
         'Jinja2>=2.5'
     ],


### PR DESCRIPTION
You get `RuntimeError: The babel data files are not available. This usually happens because you are using a source checkout from Babel and you did not build the data files.  Just make sure to run "python setup.py import_cldr" before installing the library.`

See https://travis-ci.org/palfrey/flask-babel/jobs/82117876

Locking down the Babel version to < 2.0 fixes this