### PR TITLE
Add add_direction=True option to format_timedelta

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -361,7 +361,8 @@ def format_time(time=None, format=None, rebase=True):
     return _date_format(dates.format_time, time, format, rebase)
 
 
-def format_timedelta(datetime_or_timedelta, granularity='second'):
+def format_timedelta(datetime_or_timedelta, granularity='second',
+                     add_direction=False):
     """Format the elapsed time from the given date to now or the given
     timedelta.  This currently requires an unreleased development
     version of Babel.
@@ -372,6 +373,7 @@ def format_timedelta(datetime_or_timedelta, granularity='second'):
     if isinstance(datetime_or_timedelta, datetime):
         datetime_or_timedelta = datetime.utcnow() - datetime_or_timedelta
     return dates.format_timedelta(datetime_or_timedelta, granularity,
+                                  add_direction=add_direction,
                                   locale=get_locale())
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,9 +8,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 import unittest
 from decimal import Decimal
 import flask
-from datetime import datetime
+from datetime import datetime, timedelta
 import flask_babel as babel
-from flask_babel import gettext, ngettext, lazy_gettext
+from flask_babel import gettext, ngettext, lazy_gettext, format_timedelta
 from flask_babel._compat import text_type
 
 
@@ -106,6 +106,15 @@ class DateFormattingTestCase(unittest.TestCase):
             app.config['BABEL_DEFAULT_TIMEZONE'] = 'Europe/Vienna'
             babel.refresh()
             assert babel.format_datetime(d) == 'Apr 12, 2010, 3:46:00 PM'
+
+    def test_format_timedelta(self):
+        app = flask.Flask(__name__)
+        b = babel.Babel(app)
+        d = timedelta(hours=2, minutes=3, seconds=51)
+        with app.test_request_context():
+            assert format_timedelta(d) == '2 hours'
+            assert format_timedelta(d, add_direction=True) == 'In 2 hours'
+            assert format_timedelta(-d, add_direction=True) == '2 hours ago'
 
 
 class NumberFormattingTestCase(unittest.TestCase):


### PR DESCRIPTION
Adds `add_direction=True` option to `format_timedelta()` function (`|timedeltaformat` filter).  It’s useful for rendering relative times like “2 hours ago.”