### PR TITLE
Wrap speaklater._LazyString to enable Flask's JSONEncoder

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -504,10 +504,10 @@ def npgettext(context, singular, plural, num, **variables):
     return t.unpgettext(context, singular, plural, num) % variables
 
 class LazyJsonProxy(object):
-    """Wraps a :class:`speaklater._LazyString`-like object in an object that
-    Flask can JSON-serialize.  This is done by providing an :method:`__html__`
-    method and proxying everything else to the given :class:`_LazyString`
-    object."""
+    """Wraps a :class:`speaklater._LazyString`-like object in an object
+    that Flask can JSON-serialize.  This is done by providing an
+    :method:`__html__` method and proxying everything else to the given
+    :class:`speaklater._LazyString` object."""
     def __init__(self, __proxyinner):
         self.__dict__['__proxyinner'] = __proxyinner
 


### PR DESCRIPTION
This change allows Flask's default JSONEncoder to properly serialize `speaklater._LazyString` objects into the session.  This should allow devs to use a lazy-evaluated translation for Flask-Login's flashed "you've logged in" messages and likely many other use cases.

Note: I'm making another pull request with an alternative solution that could have better performance.