### PR TITLE
Enable speaklater._LazyString for Flask JSONEncoder by subclassing

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -503,6 +503,19 @@ def npgettext(context, singular, plural, num, **variables):
         return (singular if num == 1 else plural) % variables
     return t.unpgettext(context, singular, plural, num) % variables
 
+def make_json_lazy_string(func, *args, **kwargs):
+    """Like :method:`speaklater.make_lazy_string` but returns a subclass
+    that provides an :method:`__html__` method.  That method is used by
+    :class:`flask.json.JSONEncoder` to serialize objects of unrecognized
+    types.
+    """
+    from speaklater import _LazyString
+    
+    class JsonLazyString(_LazyString):
+        __slots__ = _LazyString.__slots__ + ('__html__',)
+        def __html__(self):
+            return unicode(self)
+    return JsonLazyString(func, args, kwargs)
 
 def lazy_gettext(string, **variables):
     """Like :func:`gettext` but the string returned is lazy which means
@@ -516,8 +529,7 @@ def lazy_gettext(string, **variables):
         def index():
             return unicode(hello)
     """
-    from speaklater import make_lazy_string
-    return make_lazy_string(gettext, string, **variables)
+    return make_json_lazy_string(gettext, string, **variables)
 
 
 def lazy_pgettext(context, string, **variables):
@@ -526,5 +538,4 @@ def lazy_pgettext(context, string, **variables):
 
     .. versionadded:: 0.7
     """
-    from speaklater import make_lazy_string
-    return make_lazy_string(pgettext, context, string, **variables)
+    return make_json_lazy_string(pgettext, context, string, **variables)

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -28,7 +28,7 @@ else:
     timezone = pytz.timezone
     UTC = pytz.UTC
 
-from flask_babel._compat import string_types
+from flask_babel._compat import string_types, text_type
 
 
 class Babel(object):
@@ -512,9 +512,9 @@ def make_json_lazy_string(func, *args, **kwargs):
     from speaklater import _LazyString
     
     class JsonLazyString(_LazyString):
-        __slots__ = _LazyString.__slots__ + ('__html__',)
         def __html__(self):
-            return unicode(self)
+            return text_type(self)
+
     return JsonLazyString(func, args, kwargs)
 
 def lazy_gettext(string, **variables):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -158,9 +158,11 @@ class GettextTestCase(unittest.TestCase):
         yes = lazy_gettext(u'Yes')
         with app.test_request_context():
             assert text_type(yes) == 'Ja'
+            assert yes.__html__() == 'Ja'
         app.config['BABEL_DEFAULT_LOCALE'] = 'en_US'
         with app.test_request_context():
             assert text_type(yes) == 'Yes'
+            assert yes.__html__() == 'Yes'
 
     def test_list_translations(self):
         app = flask.Flask(__name__)


### PR DESCRIPTION
This patch subclasses `speaklater._LazyString` and adds an `__html__` method that Flask's default JSONEncoder will use to serialize a translated string.

Note:  This is an alternative implementation to https://github.com/python-babel/flask-babel/pull/81.