### PR TITLE
Babel testcase updates

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -503,6 +503,19 @@ def npgettext(context, singular, plural, num, **variables):
         return (singular if num == 1 else plural) % variables
     return t.unpgettext(context, singular, plural, num) % variables
 
+def make_json_lazy_string(func, *args, **kwargs):
+    """Like :method:`speaklater.make_lazy_string` but returns a subclass
+    that provides an :method:`__html__` method.  That method is used by
+    :class:`flask.json.JSONEncoder` to serialize objects of unrecognized
+    types.
+    """
+    from speaklater import _LazyString
+    
+    class JsonLazyString(_LazyString):
+        __slots__ = _LazyString.__slots__ + ('__html__',)
+        def __html__(self):
+            return unicode(self)
+    return JsonLazyString(func, args, kwargs)
 
 def lazy_gettext(string, **variables):
     """Like :func:`gettext` but the string returned is lazy which means
@@ -516,8 +529,7 @@ def lazy_gettext(string, **variables):
         def index():
             return unicode(hello)
     """
-    from speaklater import make_lazy_string
-    return make_lazy_string(gettext, string, **variables)
+    return make_json_lazy_string(gettext, string, **variables)
 
 
 def lazy_pgettext(context, string, **variables):
@@ -526,5 +538,4 @@ def lazy_pgettext(context, string, **variables):
 
     .. versionadded:: 0.7
     """
-    from speaklater import make_lazy_string
-    return make_lazy_string(pgettext, context, string, **variables)
+    return make_json_lazy_string(pgettext, context, string, **variables)

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -503,19 +503,6 @@ def npgettext(context, singular, plural, num, **variables):
         return (singular if num == 1 else plural) % variables
     return t.unpgettext(context, singular, plural, num) % variables
 
-def make_json_lazy_string(func, *args, **kwargs):
-    """Like :method:`speaklater.make_lazy_string` but returns a subclass
-    that provides an :method:`__html__` method.  That method is used by
-    :class:`flask.json.JSONEncoder` to serialize objects of unrecognized
-    types.
-    """
-    from speaklater import _LazyString
-    
-    class JsonLazyString(_LazyString):
-        __slots__ = _LazyString.__slots__ + ('__html__',)
-        def __html__(self):
-            return unicode(self)
-    return JsonLazyString(func, args, kwargs)
 
 def lazy_gettext(string, **variables):
     """Like :func:`gettext` but the string returned is lazy which means
@@ -529,7 +516,8 @@ def lazy_gettext(string, **variables):
         def index():
             return unicode(hello)
     """
-    return make_json_lazy_string(gettext, string, **variables)
+    from speaklater import make_lazy_string
+    return make_lazy_string(gettext, string, **variables)
 
 
 def lazy_pgettext(context, string, **variables):
@@ -538,4 +526,5 @@ def lazy_pgettext(context, string, **variables):
 
     .. versionadded:: 0.7
     """
-    return make_json_lazy_string(pgettext, context, string, **variables)
+    from speaklater import make_lazy_string
+    return make_lazy_string(pgettext, context, string, **variables)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -35,7 +35,7 @@ class DateFormattingTestCase(unittest.TestCase):
         with app.test_request_context():
             app.config['BABEL_DEFAULT_LOCALE'] = 'de_DE'
             assert babel.format_datetime(d, 'long') == \
-                '12. April 2010 15:46:00 MESZ'
+                '12. April 2010 um 15:46:00 MESZ'
 
     def test_init_app(self):
         b = babel.Babel()
@@ -57,7 +57,7 @@ class DateFormattingTestCase(unittest.TestCase):
         with app.test_request_context():
             app.config['BABEL_DEFAULT_LOCALE'] = 'de_DE'
             assert babel.format_datetime(d, 'long') == \
-                '12. April 2010 15:46:00 MESZ'
+                '12. April 2010 um 15:46:00 MESZ'
 
     def test_custom_formats(self):
         app = flask.Flask(__name__)
@@ -95,7 +95,7 @@ class DateFormattingTestCase(unittest.TestCase):
         the_timezone = 'Europe/Vienna'
 
         with app.test_request_context():
-            assert babel.format_datetime(d) == '12.04.2010 15:46:00'
+            assert babel.format_datetime(d) == '12.04.2010, 15:46:00'
 
     def test_refreshing(self):
         app = flask.Flask(__name__)


### PR DESCRIPTION
This pull request updates the Flask-Babel testcase for datetime formatting with expected values that match the locale settings in Babel.

For example, leaving Flask-Babel out of things:
```python
>>> from babel.core import Locale
>>> l = Locale.parse('de_DE')
>>> l.datetime_formats.items()
[(u'medium', u'{1}, {0}'), (u'long', u"{1} 'um' {0}"), (u'full', u"{1} 'um' {0}"), (u'short', u'{1}, {0}')]
```

Flask-Babel's current testcase expects formats without the 'um' and ',' so this pull request adds them in.