### PR TITLE
Support of printf-style string formatting in lazy_gettext

### DIFF
--- a/flask_babel/speaklater.py
+++ b/flask_babel/speaklater.py
@@ -35,6 +35,9 @@ class LazyString(object):
     def __radd__(self, other):
         return other + text_type(self)
 
+    def __mod__(self, other):
+        return text_type(self) % other
+
     def __mul__(self, other):
         return text_type(self) * other
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -224,6 +224,14 @@ class GettextTestCase(unittest.TestCase):
             assert text_type(yes) == 'Yes'
             assert yes.__html__() == 'Yes'
 
+        hello = lazy_gettext(u'Hello %(name)s!')
+        app.config['BABEL_DEFAULT_LOCALE'] = 'de_DE'
+        with app.test_request_context():
+            assert hello % {'name': 'Peter'} == 'Hallo Peter!'
+        app.config['BABEL_DEFAULT_LOCALE'] = 'en_US'
+        with app.test_request_context():
+            assert hello % {'name': 'Peter'} == 'Hello Peter!'
+
     def test_list_translations(self):
         app = flask.Flask(__name__)
         b = babel.Babel(app, default_locale='de_DE')


### PR DESCRIPTION
Recent changes to speaklater removed the ability to use printf-style formatting on lazy_gettext

E.g. this used to work before a5f22978c909c006cda45628193d90932c94ac6b
```python
>>> hello = lazy_gettext(u'Hello %(name)s!')
>>> assert hello % {'name': 'Peter'} == 'Hello Peter!'
TypeError: unsupported operand type(s) for %: 'LazyString' and 'dict'
```
