### PR TITLE
Run tests on Python 3.4 and Python 3.5 as well.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 deps = pytz>=2013a


### PR DESCRIPTION
It's 2016, after all :)