### PR TITLE
Add __repr__ to LazyString

### DIFF
--- a/flask_babel/speaklater.py
+++ b/flask_babel/speaklater.py
@@ -14,6 +14,12 @@ class LazyString(object):
             return getattr(string, attr)
         raise AttributeError(attr)
 
+    def __repr__(self):
+        try:
+            return "l'" + text_type(self) + "'"
+        except Exception:
+            return "<%s broken>" % self.__class__.__name__
+
     def __str__(self):
         return text_type(self._func(*self._args, **self._kwargs))
 

--- a/flask_babel/speaklater.py
+++ b/flask_babel/speaklater.py
@@ -15,10 +15,7 @@ class LazyString(object):
         raise AttributeError(attr)
 
     def __repr__(self):
-        try:
-            return "l'" + text_type(self) + "'"
-        except Exception:
-            return "<%s broken>" % self.__class__.__name__
+        return "l'{0}'".format(text_type(self))
 
     def __str__(self):
         return text_type(self._func(*self._args, **self._kwargs))


### PR DESCRIPTION
I work with lazy strings a lot and I have a task that uses them extensively and also produces some logging output containing them. In older versions of Flask Babel, I could simply throw a function's arguments into my logger and get a useful result. E.g. a list of tuples containing some lazy strings looked like this in the logfile:

    [(l'0 to 49', 0, 0.0), ...]

The same list became this since the update:

    [(<flask_babel.speaklater.LazyString object at 0x7f0d859e5a20>, 0, 0.0), ...]

Of course, I could wrap `str()` around every lazy string I want to log, but in case of a list, a simple `log(foo)` would become `log([str(elem) for elem in foo])`.

Adding a simple `__repr__` method (like the one of `_LazyString` of the old, standalaone speaklater) to the `LazyString` class makes life a lot easier here.