### PR TITLE
Encode LazyString __repr__ to UTF-8 on Python2

### DIFF
--- a/flask_babel/speaklater.py
+++ b/flask_babel/speaklater.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from flask_babel._compat import text_type
+from flask_babel._compat import text_type, PY2
 
 
 class LazyString(object):
@@ -17,7 +17,12 @@ class LazyString(object):
         raise AttributeError(attr)
 
     def __repr__(self):
-        return "l'{0}'".format(text_type(self))
+        value = self._func(*self._args, **self._kwargs)
+        if PY2 and isinstance(value, unicode):
+            # With Python2 we need to encode unicode strings because those
+            # can contain non-ASCII characters.
+            return "l'{0}'".format(value.encode('utf-8'))
+        return "l'{0}'".format(text_type(value))
 
     def __str__(self):
         return text_type(self._func(*self._args, **self._kwargs))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 import flask_babel as babel
 from flask_babel import gettext, ngettext, lazy_gettext, get_translations
 from babel.support import NullTranslations
-from flask_babel._compat import text_type
+from flask_babel._compat import text_type, PY2
 
 
 class IntegrationTestCase(unittest.TestCase):
@@ -284,6 +284,16 @@ class GettextTestCase(unittest.TestCase):
             assert gettext(u'Test %s') == u'Test %s'
             assert gettext(u'Test %(name)s', name=u'test') == u'Test test'
             assert gettext(u'Test %s') % 'test' == u'Test test'
+
+
+class LazyStringTestCase(unittest.TestCase):
+    def test_repr_with_non_ascii(self):
+        lazy_string = lazy_gettext(u'Hei Päivi')
+
+        if PY2:
+            assert repr(lazy_string) == "l'Hei P\xc3\xa4ivi'"
+        else:
+            assert repr(lazy_string) == "l'Hei Päivi'"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On Python2 environment encode unicode strings before returning them in
`__repr__` function. By doing the encoding to UTF-8 we avoid raising
UnicodeEncodeError:s when the string contains non-ASCII characters.

Old message:
~~When run in Python 2 environment LazyString `__repr__` raised
UnicodeEncodeError when the text contained non-ASCII characters. This
modification will change all broken `__repr__` results to
`'<LazyString broken>'` so that the function never raises.~~