### PR TITLE
New context manager: force_timezone()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -298,6 +298,8 @@ Low-Level API
 
 .. autofunction:: force_locale
 
+.. autofunction:: force_timezone
+
 
 .. _Flask: http://flask.pocoo.org/
 .. _babel: http://babel.edgewall.org/

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -204,6 +204,20 @@ class DateFormattingTestCase(unittest.TestCase):
                 assert str(babel.get_locale()) == 'en_US'
             assert str(babel.get_locale()) == 'de_DE'
 
+    def test_force_timezone(self):
+        app = flask.Flask(__name__)
+        b = babel.Babel(app)
+
+        @b.timezoneselector
+        def select_timezone():
+            return 'Europe/Berlin'
+
+        with app.test_request_context():
+            assert str(babel.get_timezone()) == 'Europe/Berlin'
+            with babel.force_timezone('America/Chicago'):
+                assert str(babel.get_timezone()) == 'America/Chicago'
+            assert str(babel.get_timezone()) == 'Europe/Berlin'
+
 
 class NumberFormattingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
As useful as forcing a specific locale, it is useful to be able to enforce a specific timezone.

In my case, I want to render a template for a specific user who has a preferred timezone, but this is not a logged in user, why it would be too complicated to implement this via a request context aware `timezoneselector`.

The implementation and behaviour of `force_timezone()` is similar to the existing context manager `force_locale()`.