### PR TITLE
Fix locale selection in multi-threaded Flask app when force_locale is used

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,6 +6,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import pickle
+from threading import Thread, Semaphore
 
 import unittest
 from decimal import Decimal
@@ -203,6 +204,46 @@ class DateFormattingTestCase(unittest.TestCase):
             with babel.force_locale('en_US'):
                 assert str(babel.get_locale()) == 'en_US'
             assert str(babel.get_locale()) == 'de_DE'
+
+    def test_force_locale_with_threading(self):
+        app = flask.Flask(__name__)
+        b = babel.Babel(app)
+
+        @b.localeselector
+        def select_locale():
+            return 'de_DE'
+
+        semaphore = Semaphore(value=0)
+
+        def first_request():
+            with app.test_request_context():
+                with babel.force_locale('en_US'):
+                    assert str(babel.get_locale()) == 'en_US'
+                    semaphore.acquire()
+
+        thread = Thread(target=first_request)
+        thread.start()
+
+        try:
+            with app.test_request_context():
+                assert str(babel.get_locale()) == 'de_DE'
+        finally:
+            semaphore.release()
+            thread.join()
+
+    def test_refresh_during_force_locale(self):
+        app = flask.Flask(__name__)
+        b = babel.Babel(app)
+
+        @b.localeselector
+        def select_locale():
+            return 'de_DE'
+
+        with app.test_request_context():
+            with babel.force_locale('en_US'):
+                assert str(babel.get_locale()) == 'en_US'
+                babel.refresh()
+                assert str(babel.get_locale()) == 'en_US'
 
 
 class NumberFormattingTestCase(unittest.TestCase):


### PR DESCRIPTION
This fixes issue #117 by setting `babel_locale` in `force_locale` context manager instead of replacing locale getter. Babel extension instance is shared across threads (through `Flask.extensions`) which may cause wrong locale to be selected in request that is processed at the same time in one thread while another thread is using `force_locale`. Setting locale to request context is thread-safe as Flask doesn't share request contexts between threads. I've added a test case to verify that this fix works, and it failed without changes to `force_locale`.