### PR TITLE
Fix issue that occurs when babel don't have NullTranslations() in support, but gettext module

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -214,7 +214,12 @@ def get_translations():
     ctx = _get_current_context()
 
     if ctx is None:
-        return support.NullTranslations()
+        try:
+            return support.NullTranslations()
+        except AttributeError:
+            # Some versions of babel have NullTranslations() in gettext instead of support module
+            import gettext
+            return gettext.NullTranslations()
 
     translations = getattr(ctx, 'babel_translations', None)
     if translations is None:


### PR DESCRIPTION
With babel 2.3.4, babel.support module don't have NullTranslations(), but we can found it in gettext.
So there's my fix that avoid having an error when it's the case.