### PR TITLE
Include README in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include Makefile LICENSE
+include Makefile LICENSE README.md
 recursive-include tests *
 recursive-exclude tests *.pyc
 recursive-exclude tests *.pyo


### PR DESCRIPTION
The current PyPI tarball doesn't have it.