### PR TITLE
Switch as much as possible to the Babel LazyProxy.

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -617,7 +617,7 @@ def lazy_gettext(string, **variables):
         def index():
             return unicode(hello)
     """
-    return LazyString(gettext, string, **variables)
+    return LazyString(gettext, string, enable_cache=False, **variables)
 
 
 def lazy_pgettext(context, string, **variables):
@@ -626,7 +626,13 @@ def lazy_pgettext(context, string, **variables):
 
     .. versionadded:: 0.7
     """
-    return LazyString(pgettext, context, string, **variables)
+    return LazyString(
+        pgettext,
+        context,
+        string,
+        enable_cache=False,
+        **variables
+    )
 
 
 def _get_current_context():

--- a/flask_babel/speaklater.py
+++ b/flask_babel/speaklater.py
@@ -1,77 +1,29 @@
 # -*- coding: utf-8 -*-
+from babel.support import LazyProxy
 from flask_babel._compat import text_type
 
 
-class LazyString(object):
-    def __init__(self, func, *args, **kwargs):
-        self._func = func
-        self._args = args
-        self._kwargs = kwargs
-
-    def __getattr__(self, attr):
-        if attr == "__setstate__":
-            raise AttributeError(attr)
-        string = text_type(self)
-        if hasattr(string, attr):
-            return getattr(string, attr)
-        raise AttributeError(attr)
-
-    def __repr__(self):
-        return "l'{0}'".format(text_type(self))
-
-    def __str__(self):
-        return text_type(self._func(*self._args, **self._kwargs))
-
-    def __len__(self):
-        return len(text_type(self))
-
-    def __getitem__(self, key):
-        return text_type(self)[key]
-
-    def __iter__(self):
-        return iter(text_type(self))
-
-    def __contains__(self, item):
-        return item in text_type(self)
-
-    def __add__(self, other):
-        return text_type(self) + other
-
-    def __radd__(self, other):
-        return other + text_type(self)
-
-    def __mul__(self, other):
-        return text_type(self) * other
-
-    def __rmul__(self, other):
-        return other * text_type(self)
-
-    def __lt__(self, other):
-        return text_type(self) < other
-
-    def __le__(self, other):
-        return text_type(self) <= other
-
-    def __eq__(self, other):
-        return text_type(self) == other
-
-    def __ne__(self, other):
-        return text_type(self) != other
-
-    def __gt__(self, other):
-        return text_type(self) > other
-
-    def __ge__(self, other):
-        return text_type(self) >= other
-
+class LazyString(LazyProxy):
     def __html__(self):
         return text_type(self)
 
-    def __hash__(self):
-        return hash(text_type(self))
+    def __setstate__(self, state):
+        object.__setattr__(self, '_func', state['_func'])
+        object.__setattr__(self, '_args', state['_args'])
+        object.__setattr__(self, '_kwargs', state['_kwargs'])
+        object.__setattr__(
+            self,
+            '_is_cache_enabled',
+            state['_is_cache_enabled']
+        )
+        object.__setattr__(self, '_value', state['_value'])
 
-    def __mod__(self, other):
-        return text_type(self) % other
 
-    def __rmod__(self, other):
-        return other + text_type(self)
+    def __getstate__(self):
+        return {
+            '_func': self._func,
+            '_args': self._args,
+            '_kwargs': self._kwargs,
+            '_is_cache_enabled': self._is_cache_enabled,
+            '_value': self._value
+        }


### PR DESCRIPTION
Babel includes a LazyProxy object which does most of the work of LazyString
for us. We can remove `__setstate__` and `__getstate__` once upstream supports
pickling.