### PR TITLE
Store forced locale per request

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -204,6 +204,29 @@ class DateFormattingTestCase(unittest.TestCase):
                 assert str(babel.get_locale()) == 'en_US'
             assert str(babel.get_locale()) == 'de_DE'
 
+    def test_force_locale_with_two_concurrent_requests(self):
+        app = flask.Flask(__name__)
+        b = babel.Babel(app)
+
+        @b.localeselector
+        def select_locale():
+            return 'de_DE'
+
+        def make_request(forced_locale):
+            with app.test_request_context():
+                assert str(babel.get_locale()) == 'de_DE'
+                with babel.force_locale(forced_locale):
+                    yield
+
+        request1 = make_request('en_US')
+        next(request1)
+
+        request2 = make_request('en_US')
+        next(request2)
+
+        next(request2, None)
+        next(request1, None)
+
 
 class NumberFormattingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Allow multiple request to share the same application.

Problem:
We are running Flask with Gunicorn with gevent worker type. This means, that when a request processing is waiting for an i/o, another request processing can start.

In my tests, I managed to have two requests use the same application object through `current_app` proxy. This introduced the following bug:

1. Request A enters `force_locale` block, which replaces `babel.locale_selector_func` with lambda A. Original `locale_selector_func` is saved.
2. Request A does some i/o work.
3. Request B is started. Request B enters `force_locale` block, which replaces `babel.locale_selector_func` with lambda B. Lambda A is saved.
4. Request B does some i/o work.
5. Request A finishes the i/o work and exits `force_locale` block. `babel.locale_selector_func` is replaced with the the original `locale_selector_func`.
6. Request B finishes the i/o work and exits `force_locale` block. `babel.locale_selector_func` is replaced by lambda A.

Now `babel.locale_selector_func` is lambda A instead of the original `locale_selector_func`.

My solution to the problem:
Store forced `locale_selector_func` per request. Try to get `locale_selector_func` first from the request info and fall back to the one stored in the application object.