### PR TITLE
Support multiple translations with different message domains

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,11 @@ change some internal defaults:
                                 ``translations``.
 `BABEL_DOMAIN`                  The message domain used by the application.
                                 Defaults to ``messages``.
+`BABEL_TRANSLATIONS`            A list of available translations with specified
+                                message domains. The list is a list of
+                                two-tuples in the format ``(translation folder,
+                                message domain)`` - for example,
+                                ``('translations', 'messages')``.
 =============================== =============================================
 
 For more complex applications you might want to have multiple applications

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -79,6 +79,40 @@ class IntegrationTestCase(unittest.TestCase):
 
             assert gettext(u'Good bye') == 'Auf Wiedersehen'
 
+    def test_multiple_translations(self):
+        """
+        Ensure we can load multiple translations with different text domains.
+        """
+        b = babel.Babel()
+        app = flask.Flask(__name__)
+
+        app.config.update({
+            'BABEL_TRANSLATION_DIRECTORIES': ';'.join((
+                'translations',
+                'renamed_translations'
+            )),
+            'BABEL_TRANSLATIONS': [
+                ('translations_different_domain', 'myapp')
+            ],
+            'BABEL_DEFAULT_LOCALE': 'de_DE'
+        })
+
+        b.init_app(app)
+
+        with app.test_request_context():
+            translations = b.list_translations()
+
+            assert(len(translations) == 3)
+            assert(str(translations[0]) == 'de')
+            assert(str(translations[1]) == 'de')
+            assert(str(translations[2]) == 'de')
+
+            assert gettext(
+                u'Hello %(name)s!',
+                name='Peter'
+            ) == 'Hallo Peter!'
+            assert gettext(u'Good bye') == 'Auf Wiedersehen'
+
     def test_lazy_old_style_formatting(self):
         lazy_string = lazy_gettext(u'Hello %(name)s')
         assert lazy_string % {u'name': u'test'} == u'Hello test'


### PR DESCRIPTION
This pull request is to add a feature that support multiple language catalogs with different localization domains which is provided by [flask-babelex](https://github.com/mrjoes/flask-babelex).

Currently many flask extensions use flask-babelex to package their own localization file(s), e.g. **flask-security**, **flask-admin** etc. There are super annoying incompatibilities([mattupstate/flask-security#715](https://github.com/mattupstate/flask-security/issues/715), [lingthio/Flask-User#195](https://github.com/lingthio/Flask-User/issues/195)) when combined **flask-babelex** with **flask-babel** and the development of **flask-babelex** seems stuck.