### PR TITLE
Remove pytz.gae refecence

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -17,13 +17,7 @@ from flask import current_app, request
 from flask.ctx import has_request_context
 from babel import dates, numbers, support, Locale
 from werkzeug import ImmutableDict
-try:
-    from pytz.gae import pytz
-except ImportError:
-    from pytz import timezone, UTC
-else:
-    timezone = pytz.timezone
-    UTC = pytz.UTC
+from pytz import timezone, UTC
 
 from flask_babel._compat import string_types
 from flask_babel.speaklater import LazyString


### PR DESCRIPTION
pytz is available in standard Python 2.7 environment in GAE, see
https://cloud.google.com/appengine/docs/standard/python/tools/built-in-libraries-27