### PR TITLE
Fix werkzeug deprecation warning

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 from flask import current_app, request
 from flask.ctx import has_request_context
 from babel import dates, numbers, support, Locale
-from werkzeug import ImmutableDict
+from werkzeug.datastructures import ImmutableDict
 try:
     from pytz.gae import pytz
 except ImportError:


### PR DESCRIPTION
Fix for 
```
 The import 'werkzeug.ImmutableDict' is deprecated and will be removed in Werkzeug 1.0. Use 'from werkzeug.datastructures import ImmutableDict' instead.
    from werkzeug import ImmutableDict
```