### PR TITLE
v3.0.0 - Removing all format_ wrappers, cleanups, and code quality.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/_themes"]
-	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -18,7 +18,6 @@ class Babel(object):
         self._default_domain = default_domain
         self._configure_jinja = configure_jinja
 
-        self.app = app
         self.locale_selector_func = None
         self.timezone_selector_func = None
 
@@ -29,8 +28,6 @@ class Babel(object):
         """Set up this instance for use with *app*, if no app was passed to
         the constructor.
         """
-        self.app = app
-
         if not hasattr(app, 'extensions'):
             app.extensions = {}
 
@@ -139,7 +136,7 @@ class Babel(object):
 
     @property
     def translation_directories(self):
-        directories = self.app.config.get(
+        directories = current_app.config.get(
             'BABEL_TRANSLATION_DIRECTORIES',
             'translations'
         ).split(';')
@@ -148,7 +145,7 @@ class Babel(object):
             if os.path.isabs(path):
                 yield path
             else:
-                yield os.path.join(self.app.root_path, path)
+                yield os.path.join(current_app.root_path, path)
 
 
 def get_translations():

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -522,7 +522,10 @@ class Domain(object):
         self.cache = {}
 
     def __repr__(self):
-        return '<Domain({!r}, {!r})>'.format(self._translation_directories, self.domain)
+        return '<Domain({!r}, {!r})>'.format(
+            self._translation_directories,
+            self.domain
+        )
 
     @property
     def translation_directories(self):
@@ -565,9 +568,9 @@ class Domain(object):
                 )
                 translations.merge(catalog)
                 # FIXME: Workaround for merge() being really, really stupid. It
-                # does not copy _info, plural(), or any other instance variables
-                # populated by GNUTranslations. We probably want to stop using
-                # `support.Translations.merge` entirely.
+                # does not copy _info, plural(), or any other instance
+                # variables populated by GNUTranslations. We probably want to
+                # stop using `support.Translations.merge` entirely.
                 if hasattr(catalog, 'plural'):
                     translations.plural = catalog.plural
 
@@ -629,7 +632,7 @@ class Domain(object):
 
         Example::
 
-            hello = lazy_gettext(u'Hello World')
+            hello = lazy_gettext('Hello World')
 
             @app.route('/')
             def index():
@@ -643,7 +646,11 @@ class Domain(object):
 
         Example::
 
-            apples = lazy_ngettext(u'%(num)d Apple', u'%(num)d Apples', num=len(apples))
+            apples = lazy_ngettext(
+                '%(num)d Apple',
+                '%(num)d Apples',
+                num=len(apples)
+            )
 
             @app.route('/')
             def index():
@@ -687,6 +694,8 @@ def get_domain():
 # Create shortcuts for the default Flask domain
 def gettext(*args, **kwargs):
     return get_domain().gettext(*args, **kwargs)
+
+
 _ = gettext
 
 

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -1,60 +1,23 @@
-"""
-    flaskext.babel
-    ~~~~~~~~~~~~~~
-
-    Implements i18n/l10n support for Flask applications based on Babel.
-
-    :copyright: (c) 2013 by Armin Ronacher, Daniel Neuhäuser.
-    :license: BSD, see LICENSE for more details.
-"""
-from __future__ import absolute_import
 import os
 
-from datetime import datetime
 from contextlib import contextmanager
 from flask import current_app, request
 from flask.ctx import has_request_context
 from flask.helpers import locked_cached_property
-from babel import dates, numbers, support, Locale
-from pytz import timezone, UTC
-from werkzeug.datastructures import ImmutableDict
+from babel import support, Locale
+from pytz import timezone
 
 from flask_babel.speaklater import LazyString
 
 
 class Babel(object):
-    """Central controller class that can be used to configure how
-    Flask-Babel behaves.  Each application that wants to use Flask-Babel
-    has to create, or run :meth:`init_app` on, an instance of this class
-    after the configuration was initialized.
-    """
-
-    default_date_formats = ImmutableDict({
-        'time':             'medium',
-        'date':             'medium',
-        'datetime':         'medium',
-        'time.short':       None,
-        'time.medium':      None,
-        'time.full':        None,
-        'time.long':        None,
-        'date.short':       None,
-        'date.medium':      None,
-        'date.full':        None,
-        'date.long':        None,
-        'datetime.short':   None,
-        'datetime.medium':  None,
-        'datetime.full':    None,
-        'datetime.long':    None,
-    })
-
     def __init__(self, app=None, default_locale='en', default_timezone='UTC',
-                 default_domain='messages', date_formats=None,
-                 configure_jinja=True):
+                 default_domain='messages', configure_jinja=True):
         self._default_locale = default_locale
         self._default_timezone = default_timezone
         self._default_domain = default_domain
-        self._date_formats = date_formats
         self._configure_jinja = configure_jinja
+
         self.app = app
         self.locale_selector_func = None
         self.timezone_selector_func = None
@@ -67,43 +30,31 @@ class Babel(object):
         the constructor.
         """
         self.app = app
-        app.babel_instance = self
+
         if not hasattr(app, 'extensions'):
             app.extensions = {}
+
+        # Several extensions, such as Flask-WTF, check for this value before
+        # using get_locale. Don't remove or rename without thought.
         app.extensions['babel'] = self
 
-        app.config.setdefault('BABEL_DEFAULT_LOCALE', self._default_locale)
-        app.config.setdefault('BABEL_DEFAULT_TIMEZONE', self._default_timezone)
-        app.config.setdefault('BABEL_DOMAIN', self._default_domain)
-        if self._date_formats is None:
-            self._date_formats = self.default_date_formats.copy()
+        self._default_locale = Locale.parse(
+            app.config.get('BABEL_DEFAULT_LOCALE', self._default_locale)
+        )
+        self._default_timezone = timezone(
+            app.config.get('BABEL_DEFAULT_TIMEZONE', self._default_timezone)
+        )
 
-        #: a mapping of Babel datetime format strings that can be modified
-        #: to change the defaults.  If you invoke :func:`format_datetime`
-        #: and do not provide any format string Flask-Babel will do the
-        #: following things:
-        #:
-        #: 1.   look up ``date_formats['datetime']``.  By default ``'medium'``
-        #:      is returned to enforce medium length datetime formats.
-        #: 2.   ``date_formats['datetime.medium'] (if ``'medium'`` was
-        #:      returned in step one) is looked up.  If the return value
-        #:      is anything but `None` this is used as new format string.
-        #:      otherwise the default for that language is used.
-        self.date_formats = self._date_formats
+        self._default_domain = app.config.get(
+            'BABEL_DEFAULT_DOMAIN',
+            app.config.get(
+                # Legacy configuration key.
+                'BABEL_DOMAIN',
+                self._default_timezone
+            )
+        )
 
         if self._configure_jinja:
-            app.jinja_env.filters.update(
-                datetimeformat=format_datetime,
-                dateformat=format_date,
-                timeformat=format_time,
-                timedeltaformat=format_timedelta,
-
-                numberformat=format_number,
-                decimalformat=format_decimal,
-                currencyformat=format_currency,
-                percentformat=format_percent,
-                scientificformat=format_scientific,
-            )
             app.jinja_env.add_extension('jinja2.ext.i18n')
             app.jinja_env.install_gettext_callables(
                 lambda x: get_translations().ugettext(x),
@@ -161,27 +112,27 @@ class Babel(object):
         return result
 
     @property
-    def default_locale(self):
+    def default_locale(self) -> Locale:
         """The default locale from the configuration as instance of a
         `babel.Locale` object.
         """
-        return Locale.parse(self.app.config['BABEL_DEFAULT_LOCALE'])
+        return self._default_locale
 
     @property
-    def default_timezone(self):
+    def default_timezone(self) -> timezone:
         """The default timezone from the configuration as instance of a
         `pytz.timezone` object.
         """
-        return timezone(self.app.config['BABEL_DEFAULT_TIMEZONE'])
+        return self._default_timezone
 
     @property
     def domain(self):
         """The message domain for the translations as a string.
         """
-        return self.app.config['BABEL_DOMAIN']
+        return self._default_domain
 
     @locked_cached_property
-    def domain_instance(self):
+    def domain_instance(self) -> 'Domain':
         """The message domain for the translations.
         """
         return Domain(domain=self.app.config['BABEL_DOMAIN'])
@@ -217,6 +168,7 @@ def get_locale():
     ctx = _get_current_context()
     if ctx is None:
         return None
+
     locale = getattr(ctx, 'babel_locale', None)
     if locale is None:
         babel = current_app.extensions['babel']
@@ -229,6 +181,7 @@ def get_locale():
             else:
                 locale = Locale.parse(rv)
         ctx.babel_locale = locale
+
     return locale
 
 
@@ -311,209 +264,12 @@ def force_locale(locale):
             setattr(ctx, key, value)
 
 
-def _get_format(key, format):
-    """A small helper for the datetime formatting functions.  Looks up
-    format defaults for different kinds.
-    """
-    babel = current_app.extensions['babel']
-    if format is None:
-        format = babel.date_formats[key]
-    if format in ('short', 'medium', 'full', 'long'):
-        rv = babel.date_formats['%s.%s' % (key, format)]
-        if rv is not None:
-            format = rv
-    return format
-
-
-def to_user_timezone(datetime):
-    """Convert a datetime object to the user's timezone.  This automatically
-    happens on all date formatting unless rebasing is disabled.  If you need
-    to convert a :class:`datetime.datetime` object at any time to the user's
-    timezone (as returned by :func:`get_timezone` this function can be used).
-    """
-    if datetime.tzinfo is None:
-        datetime = datetime.replace(tzinfo=UTC)
-    tzinfo = get_timezone()
-    return tzinfo.normalize(datetime.astimezone(tzinfo))
-
-
-def to_utc(datetime):
-    """Convert a datetime object to UTC and drop tzinfo.  This is the
-    opposite operation to :func:`to_user_timezone`.
-    """
-    if datetime.tzinfo is None:
-        datetime = get_timezone().localize(datetime)
-    return datetime.astimezone(UTC).replace(tzinfo=None)
-
-
-def format_datetime(datetime=None, format=None, rebase=True):
-    """Return a date formatted according to the given pattern.  If no
-    :class:`~datetime.datetime` object is passed, the current time is
-    assumed.  By default rebasing happens which causes the object to
-    be converted to the users's timezone (as returned by
-    :func:`to_user_timezone`).  This function formats both date and
-    time.
-
-    The format parameter can either be ``'short'``, ``'medium'``,
-    ``'long'`` or ``'full'`` (in which cause the language's default for
-    that setting is used, or the default from the :attr:`Babel.date_formats`
-    mapping is used) or a format string as documented by Babel.
-
-    This function is also available in the template context as filter
-    named `datetimeformat`.
-    """
-    format = _get_format('datetime', format)
-    return _date_format(dates.format_datetime, datetime, format, rebase)
-
-
-def format_date(date=None, format=None, rebase=True):
-    """Return a date formatted according to the given pattern.  If no
-    :class:`~datetime.datetime` or :class:`~datetime.date` object is passed,
-    the current time is assumed.  By default rebasing happens which causes
-    the object to be converted to the users's timezone (as returned by
-    :func:`to_user_timezone`).  This function only formats the date part
-    of a :class:`~datetime.datetime` object.
-
-    The format parameter can either be ``'short'``, ``'medium'``,
-    ``'long'`` or ``'full'`` (in which cause the language's default for
-    that setting is used, or the default from the :attr:`Babel.date_formats`
-    mapping is used) or a format string as documented by Babel.
-
-    This function is also available in the template context as filter
-    named `dateformat`.
-    """
-    if rebase and isinstance(date, datetime):
-        date = to_user_timezone(date)
-    format = _get_format('date', format)
-    return _date_format(dates.format_date, date, format, rebase)
-
-
-def format_time(time=None, format=None, rebase=True):
-    """Return a time formatted according to the given pattern.  If no
-    :class:`~datetime.datetime` object is passed, the current time is
-    assumed.  By default rebasing happens which causes the object to
-    be converted to the users's timezone (as returned by
-    :func:`to_user_timezone`).  This function formats both date and
-    time.
-
-    The format parameter can either be ``'short'``, ``'medium'``,
-    ``'long'`` or ``'full'`` (in which cause the language's default for
-    that setting is used, or the default from the :attr:`Babel.date_formats`
-    mapping is used) or a format string as documented by Babel.
-
-    This function is also available in the template context as filter
-    named `timeformat`.
-    """
-    format = _get_format('time', format)
-    return _date_format(dates.format_time, time, format, rebase)
-
-
-def format_timedelta(datetime_or_timedelta, granularity='second',
-                     add_direction=False, threshold=0.85):
-    """Format the elapsed time from the given date to now or the given
-    timedelta.
-
-    This function is also available in the template context as filter
-    named `timedeltaformat`.
-    """
-    if isinstance(datetime_or_timedelta, datetime):
-        datetime_or_timedelta = datetime.utcnow() - datetime_or_timedelta
-    return dates.format_timedelta(
-        datetime_or_timedelta,
-        granularity,
-        threshold=threshold,
-        add_direction=add_direction,
-        locale=get_locale()
-    )
-
-
-def _date_format(formatter, obj, format, rebase, **extra):
-    """Internal helper that formats the date."""
-    locale = get_locale()
-    extra = {}
-    if formatter is not dates.format_date and rebase:
-        extra['tzinfo'] = get_timezone()
-    return formatter(obj, format, locale=locale, **extra)
-
-
-def format_number(number):
-    """Return the given number formatted for the locale in request
-
-    :param number: the number to format
-    :return: the formatted number
-    :rtype: unicode
-    """
-    locale = get_locale()
-    return numbers.format_decimal(number, locale=locale)
-
-
-def format_decimal(number, format=None):
-    """Return the given decimal number formatted for the locale in request
-
-    :param number: the number to format
-    :param format: the format to use
-    :return: the formatted number
-    :rtype: unicode
-    """
-    locale = get_locale()
-    return numbers.format_decimal(number, format=format, locale=locale)
-
-
-def format_currency(number, currency, format=None, currency_digits=True,
-                    format_type='standard'):
-    """Return the given number formatted for the locale in request
-
-    :param number: the number to format
-    :param currency: the currency code
-    :param format: the format to use
-    :param currency_digits: use the currency’s number of decimal digits
-                            [default: True]
-    :param format_type: the currency format type to use
-                        [default: standard]
-    :return: the formatted number
-    :rtype: unicode
-    """
-    locale = get_locale()
-    return numbers.format_currency(
-        number,
-        currency,
-        format=format,
-        locale=locale,
-        currency_digits=currency_digits,
-        format_type=format_type
-    )
-
-
-def format_percent(number, format=None):
-    """Return formatted percent value for the locale in request
-
-    :param number: the number to format
-    :param format: the format to use
-    :return: the formatted percent number
-    :rtype: unicode
-    """
-    locale = get_locale()
-    return numbers.format_percent(number, format=format, locale=locale)
-
-
-def format_scientific(number, format=None):
-    """Return value formatted in scientific notation for the locale in request
-
-    :param number: the number to format
-    :param format: the format to use
-    :return: the formatted percent number
-    :rtype: unicode
-    """
-    locale = get_locale()
-    return numbers.format_scientific(number, format=format, locale=locale)
-
-
 class Domain(object):
-    """Localization domain. By default will use look for tranlations in Flask
-    application directory and "messages" domain - all message catalogs should
-    be called ``messages.mo``.
-    """
+    """Localization domain.
 
+    By default will look for translations in Flask application directory and
+    "messages" domain.
+    """
     def __init__(self, translation_directories=None, domain='messages'):
         if isinstance(translation_directories, str):
             translation_directories = [translation_directories]
@@ -543,20 +299,15 @@ class Domain(object):
 
         ctx.babel_domain = self
 
-    def get_translations_cache(self, ctx):
-        """Returns dictionary-like object for translation caching"""
-        return self.cache
-
     def get_translations(self):
         ctx = _get_current_context()
 
         if ctx is None:
             return support.NullTranslations()
 
-        cache = self.get_translations_cache(ctx)
         locale = get_locale()
         try:
-            return cache[str(locale), self.domain]
+            return self.cache[str(locale), self.domain]
         except KeyError:
             translations = support.Translations()
 
@@ -574,97 +325,8 @@ class Domain(object):
                 if hasattr(catalog, 'plural'):
                     translations.plural = catalog.plural
 
-            cache[str(locale), self.domain] = translations
+            self.cache[str(locale), self.domain] = translations
             return translations
-
-    def gettext(self, string, **variables):
-        """Translates a string with the current locale and passes in the
-        given keyword arguments as mapping to a string formatting string.
-
-        ::
-
-            gettext(u'Hello World!')
-            gettext(u'Hello %(name)s!', name='World')
-        """
-        t = self.get_translations()
-        s = t.ugettext(string)
-        return s if not variables else s % variables
-
-    def ngettext(self, singular, plural, num, **variables):
-        """Translates a string with the current locale and passes in the
-        given keyword arguments as mapping to a string formatting string.
-        The `num` parameter is used to dispatch between singular and various
-        plural forms of the message.  It is available in the format string
-        as ``%(num)d`` or ``%(num)s``.  The source language should be
-        English or a similar language which only has one plural form.
-
-        ::
-
-            ngettext(u'%(num)d Apple', u'%(num)d Apples', num=len(apples))
-        """
-        variables.setdefault('num', num)
-        t = self.get_translations()
-        s = t.ungettext(singular, plural, num)
-        return s if not variables else s % variables
-
-    def pgettext(self, context, string, **variables):
-        """Like :func:`gettext` but with a context.
-
-        .. versionadded:: 0.7
-        """
-        t = self.get_translations()
-        s = t.upgettext(context, string)
-        return s if not variables else s % variables
-
-    def npgettext(self, context, singular, plural, num, **variables):
-        """Like :func:`ngettext` but with a context.
-
-        .. versionadded:: 0.7
-        """
-        variables.setdefault('num', num)
-        t = self.get_translations()
-        s = t.unpgettext(context, singular, plural, num)
-        return s if not variables else s % variables
-
-    def lazy_gettext(self, string, **variables):
-        """Like :func:`gettext` but the string returned is lazy which means
-        it will be translated when it is used as an actual string.
-
-        Example::
-
-            hello = lazy_gettext('Hello World')
-
-            @app.route('/')
-            def index():
-                return unicode(hello)
-        """
-        return LazyString(self.gettext, string, **variables)
-
-    def lazy_ngettext(self, singular, plural, num, **variables):
-        """Like :func:`ngettext` but the string returned is lazy which means
-        it will be translated when it is used as an actual string.
-
-        Example::
-
-            apples = lazy_ngettext(
-                '%(num)d Apple',
-                '%(num)d Apples',
-                num=len(apples)
-            )
-
-            @app.route('/')
-            def index():
-                return unicode(apples)
-        """
-        return LazyString(self.ngettext, singular, plural, num, **variables)
-
-    def lazy_pgettext(self, context, string, **variables):
-        """Like :func:`pgettext` but the string returned is lazy which means
-        it will be translated when it is used as an actual string.
-
-        .. versionadded:: 0.7
-        """
-        return LazyString(self.pgettext, context, string, **variables)
 
 
 def _get_current_context():
@@ -691,7 +353,6 @@ def get_domain():
     return ctx.babel_domain
 
 
-# Create shortcuts for the default Flask domain
 def gettext(*args, **kwargs):
     return get_domain().gettext(*args, **kwargs)
 


### PR DESCRIPTION
We currently (v1, v2) duplicate all of the babel.dates and babel.numbers `format_*` methods in Flask-Babel. This is a lot of completely unnecessary duplication, including docstrings and test coverage. We're also often out of date with babel's methods,  such as when new kwargs are added. Just like flask-wtf did way back, we should chuck this and become just the glue layer between Flask and Babel. In general, the only change in your code is to add `format_decimal(..., locale=get_locale())`.

Because this PR reduces our surface area significantly, lets make it a goal to get 100% test coverage.

- [ ] Update documentation (#173)
- [x] Remove format helpers (#164)
- [ ] Remove all old-style formatters in `__init__` and test code. (`%` vs `format()`). Or bump to py3.6+ and use fstrings.
- [ ] Support new-style strings for translation (#170)
- [ ] 100% test coverage, and make it part of the tests.
- [ ] 100% flake8, and make it part of the tests.
- [ ] Cleanup how we handle translation context. Verify we are thread safe.
- [ ] Stop polluting app objects - always use current_app.
- [ ] Support multiple apps with different configurations (#107)

The v3.* family aims to be the last breaking release for quite awhile.