### PR TITLE
Fix force locale in app context and multiple threads

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -9,11 +9,11 @@
 """
 from __future__ import absolute_import
 import os
+from types import SimpleNamespace
 
 from datetime import datetime
 from contextlib import contextmanager
-from flask import current_app, request
-from flask.ctx import has_request_context
+from flask import current_app, g
 from flask.helpers import locked_cached_property
 from babel import dates, numbers, support, Locale
 from pytz import timezone, UTC
@@ -661,11 +661,13 @@ class Domain(object):
 
 
 def _get_current_context():
-    if has_request_context():
-        return request
+    if not g:
+        return None
 
-    if current_app:
-        return current_app
+    if not hasattr(g, "_flask_babel"):
+        g._flask_babel = SimpleNamespace()
+
+    return g._flask_babel
 
 
 def get_domain():

--- a/tests/test_force_locale.py
+++ b/tests/test_force_locale.py
@@ -1,0 +1,62 @@
+from threading import Semaphore, Thread
+
+import flask
+
+import flask_babel as babel
+
+
+def test_force_locale():
+    app = flask.Flask(__name__)
+    b = babel.Babel(app)
+
+    @b.localeselector
+    def select_locale():
+        return 'de_DE'
+
+    with app.test_request_context():
+        assert str(babel.get_locale()) == 'de_DE'
+        with babel.force_locale('en_US'):
+            assert str(babel.get_locale()) == 'en_US'
+        assert str(babel.get_locale()) == 'de_DE'
+
+
+def test_force_locale_with_threading():
+    app = flask.Flask(__name__)
+    b = babel.Babel(app)
+
+    @b.localeselector
+    def select_locale():
+        return 'de_DE'
+
+    semaphore = Semaphore(value=0)
+
+    def first_request():
+        with app.test_request_context():
+            with babel.force_locale('en_US'):
+                assert str(babel.get_locale()) == 'en_US'
+                semaphore.acquire()
+
+    thread = Thread(target=first_request)
+    thread.start()
+
+    try:
+        with app.test_request_context():
+            assert str(babel.get_locale()) == 'de_DE'
+    finally:
+        semaphore.release()
+        thread.join()
+
+
+def test_refresh_during_force_locale():
+    app = flask.Flask(__name__)
+    b = babel.Babel(app)
+
+    @b.localeselector
+    def select_locale():
+        return 'de_DE'
+
+    with app.test_request_context():
+        with babel.force_locale('en_US'):
+            assert str(babel.get_locale()) == 'en_US'
+            babel.refresh()
+            assert str(babel.get_locale()) == 'en_US'


### PR DESCRIPTION
Locale set by a `force_locale` context manager leaks between multiple threads when `force_locale` is used in application context rather than request context. This can be fixed by using `flask.globals._app_ctx_stack` as recommended by [Flask documentation on extension development](https://flask.palletsprojects.com/en/1.1.x/extensiondev/). Unlike `current_app`, the object on top of the `_app_ctx_stack` object is different in every application context so any attributes set to it do not change the same attributes in a different application context. This pull request is similar to #144, but it adds a test for the bug that the change fixes and moves tests related to `force_locale` to a new test module.