### PR TITLE
Fix check for presence of .mo file in translation directories

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -151,7 +151,7 @@ class Babel(object):
                 if not os.path.isdir(locale_dir):
                     continue
 
-                if filter(lambda x: x.endswith('.mo'), os.listdir(locale_dir)):
+                if any(x.endswith('.mo') for x in os.listdir(locale_dir)):
                     result.append(Locale.parse(folder))
 
         # If not other translations are found, add the default locale.

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -1,6 +1,6 @@
 """
-    flaskext.babel
-    ~~~~~~~~~~~~~~
+    flask_babel
+    ~~~~~~~~~~~
 
     Implements i18n/l10n support for Flask applications based on Babel.
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,6 +22,9 @@ def test_no_request_context():
 def test_multiple_directories():
     """
     Ensure we can load translations from multiple directories.
+
+    This also ensures that directories without any translation files
+    are not taken into account.
     """
     b = babel.Babel()
     app = flask.Flask(__name__)


### PR DESCRIPTION
In Python 2 the `filter()` worked because it returned a list, but in Python 3 it's a generator which is never falsy.

Note that, while a bugfix, this could break applications where someone relied on this bug. However, I think it's very unlikely so probably safe for a bugfix release.