### PR TITLE
Install `pgettext`, `npgettext` for Jinja templates

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -106,9 +106,11 @@ class Babel(object):
             )
             app.jinja_env.add_extension('jinja2.ext.i18n')
             app.jinja_env.install_gettext_callables(
-                lambda x: get_translations().ugettext(x),
-                lambda s, p, n: get_translations().ungettext(s, p, n),
-                newstyle=True
+                gettext=lambda s: get_translations().ugettext(s),
+                ngettext=lambda s, p, n: get_translations().ungettext(s, p, n),
+                newstyle=True,
+                pgettext=lambda c, s: get_translations().upgettext(c, s),
+                npgettext=lambda c, s, p, n: get_translations().unpgettext(c, s, p, n),
             )
 
     def localeselector(self, f):


### PR DESCRIPTION
This makes these callables (instead of `None` in both cases) available for use as functions in Jinja templates using Flask's/Jinja's own hook.

I took the liberty to turn the first two positional arguments into keyword arguments to align with the rest of the arguments and make it easier to understand what they refer to.

I also renamed the argument `x` to `s` (for "string") as used in the implementation of `Domain.gettext` to align it with the other anonymous functions' arguments' names.