### PR TITLE
Allow loading translations for a specific locale

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -514,11 +514,12 @@ class Domain(object):
     be called ``messages.mo``.
     """
 
-    def __init__(self, translation_directories=None, domain='messages'):
+    def __init__(self, translation_directories=None, domain='messages', locale=None):
         if isinstance(translation_directories, str):
             translation_directories = [translation_directories]
         self._translation_directories = translation_directories
         self.domain = domain
+        self.locale = locale
         self.cache = {}
 
     def __repr__(self):
@@ -551,7 +552,7 @@ class Domain(object):
             return support.NullTranslations()
 
         cache = self.get_translations_cache(ctx)
-        locale = get_locale()
+        locale = self.locale or get_locale()
         try:
             return cache[str(locale), self.domain]
         except KeyError:


### PR DESCRIPTION
So far, flask_babel supports translation to the locale selected for the request. If one needs a translation into a different locale, one would need to replicate parts of flask_babel's code. A use case for this is, for example, sending an email to a site administrator in the admininistrator's language.

    from flask_babel import Domain
    from babel import Locale

    domain = Domain(locale=Locale.parse(admin_lang))
    email_body = render_template('admin_email.html', _=domain.gettext)