### PR TITLE
Specify jinja2 compatible versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'pytz',
         'Flask',
         'Babel>=2.3',
-        'Jinja2>=2.5'
+        'Jinja2>=2.5, <3.0.0'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Jinja2 moved jina2.ext.autoescape. See [Issue 195](https://github.com/python-babel/flask-babel/issues/195)