### PR TITLE
docs: fix simple typo, tranlations -> translations

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -509,7 +509,7 @@ def format_scientific(number, format=None):
 
 
 class Domain(object):
-    """Localization domain. By default will use look for tranlations in Flask
+    """Localization domain. By default will use look for translations in Flask
     application directory and "messages" domain - all message catalogs should
     be called ``messages.mo``.
     """


### PR DESCRIPTION
There is a small typo in flask_babel/__init__.py.

Should read `translations` rather than `tranlations`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md