### PR TITLE
Do not include documentation files in wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ classifiers = [
     'Topic :: Software Development :: Libraries :: Python Modules'
 ]
 include = [
-    "CHANGELOG",
-    "README.md",
-    "LICENSE"
+    { path = "CHANGELOG", format = "sdist" },
+    { path = "README.md", format = "sdist" },
+    { path = "LICENSE", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Fix the `include` entries in `pyproject.toml` to include documentation files in sdist format only.  Otherwise, they are added to the top-level wheel directory and they end up being installed directly in the top-level site-packages directory, e.g.:

    /usr/lib/python3.11/site-packages/CHANGELOG
    /usr/lib/python3.11/site-packages/LICENSE
    /usr/lib/python3.11/site-packages/README.md