### PR TITLE
Fix list_translations() not to return default locale twice

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -197,7 +197,8 @@ class Babel:
                 if any(x.endswith('.mo') for x in os.listdir(locale_dir)):
                     result.append(Locale.parse(folder))
 
-        result.append(self.default_locale)
+        if self.default_locale not in result:
+            result.append(self.default_locale)
         return result
 
     @property

--- a/tests/test_gettext.py
+++ b/tests/test_gettext.py
@@ -96,6 +96,16 @@ def test_list_translations():
         assert str(translations[1]) == 'de_DE'
 
 
+def test_list_translations_default_locale_exists():
+    app = flask.Flask(__name__)
+    b = babel.Babel(app, default_locale='de')
+
+    with app.app_context():
+        translations = b.list_translations()
+        assert len(translations) == 1
+        assert str(translations[0]) == 'de'
+
+
 def test_no_formatting():
     """
     Ensure we don't format strings unless a variable is passed.


### PR DESCRIPTION
`list_translations()` was returning the default locale twice if there was a translation file for the default locale.