### PR TITLE
Fix typo in config options example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,7 +57,7 @@ to change some internal defaults:
                                 translation directories, eg::
 
                                     BABEL_TRANSLATION_DIRECTORIES=/path/to/translations;/another/path/
-                                    BABEL_DOMAINS=messages;myapp
+                                    BABEL_DOMAIN=messages;myapp
 
 =============================== =============================================
 


### PR DESCRIPTION
There is no `BABEL_DOMAINS`, it's just `BABEL_DOMAIN`. I introduced this back in  python-babel/flask-babel#194