### PR TITLE
Remove incorrect upper bound from `pytz` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pytz = "^2022.7"
+pytz = ">=2022.7"
 Flask = "^2.0.0"
 Babel = "^2.12.0"
 Jinja2 = "^3.1.2"


### PR DESCRIPTION
Change the `pytz` dependency to use the `>=` operator rather than `^`, in order to allow installing newer versions.  `pytz` uses calendar versioning rather than semantic versioning, so the `^` operator is meaningless there.  Furthermore, since `pytz` version corresponds to the timezone data release, allowing the newest version is important to permit using up-to-date tzinfo.