### PR TITLE
replace deprecated locked_cached_property decorator with cached_property

### DIFF
--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -16,10 +16,10 @@ from typing import List, Callable, Optional, Union
 
 from babel.support import Translations, NullTranslations
 from flask import current_app, g
-from flask.helpers import locked_cached_property
 from babel import dates, numbers, support, Locale
 from pytz import timezone, UTC
 from werkzeug.datastructures import ImmutableDict
+from werkzeug.utils import cached_property
 
 from flask_babel.speaklater import LazyString
 
@@ -221,7 +221,7 @@ class Babel:
         """
         return get_babel().default_domain
 
-    @locked_cached_property
+    @cached_property
     def domain_instance(self):
         """The message domain for the translations.
         """


### PR DESCRIPTION
resolves #229 

As discussed in #229, this replaces the deprecated `@locked_cached_property` with the `@cached_property`, since locking is not needed.