### PR TITLE
improve format_percent

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -186,8 +186,10 @@ u'1.235'
 '$1,099.98'
 
 >>> from flask_babel import format_percent
->>> format_percent(0.34)
+>>> format_percent(0.3399)
 '34%'
+>>> format_percent(0.3399, decimal_quantization=False)
+'33.99%'
 
 >>> from flask_babel import format_scientific
 >>> format_scientific(10000)

--- a/flask_babel/__init__.py
+++ b/flask_babel/__init__.py
@@ -520,16 +520,18 @@ def format_currency(number, currency, format=None, currency_digits=True,
     )
 
 
-def format_percent(number, format=None) -> str:
+def format_percent(number, format=None, decimal_quantization=True) -> str:
     """Return formatted percent value for the locale in the request.
 
     :param number: the number to format
     :param format: the format to use
+    :param decimal_quantization: Truncate and round high-precision numbers to
+                                 the format pattern. Defaults to `True`.
     :return: the formatted percent number
     :rtype: unicode
     """
     locale = get_locale()
-    return numbers.format_percent(number, format=format, locale=locale)
+    return numbers.format_percent(number, format=format, locale=locale, decimal_quantization=decimal_quantization)
 
 
 def format_scientific(number, format=None) -> str:

--- a/tests/test_number_formatting.py
+++ b/tests/test_number_formatting.py
@@ -15,4 +15,6 @@ def test_basics():
         assert babel.format_decimal(Decimal('1010.99')) == u'1,010.99'
         assert babel.format_currency(n, 'USD') == '$1,099.00'
         assert babel.format_percent(0.19) == '19%'
+        assert babel.format_percent(0.1999,
+                                    decimal_quantization=False) == '19.99%'
         assert babel.format_scientific(10000) == u'1E4'


### PR DESCRIPTION
Hello,

When using the _**format_percent**_ function, I noticed that the percentage value always rounded to an integer. That's why I set out to improve it.

I added another parameter that determines whether or not the result should be rounded.

This parameter already exists in the format_percent function of babel.numbers, so I just made the call.

grateful!
