### PR TITLE
Fix list-translations() ordering in tests

### DIFF
--- a/tests/test_gettext.py
+++ b/tests/test_gettext.py
@@ -91,11 +91,11 @@ def test_list_translations():
     b = babel.Babel(app, default_locale="de_DE")
 
     with app.app_context():
-        translations = b.list_translations()
+        translations = sorted(b.list_translations(), key=str)
         assert len(translations) == 3
         assert str(translations[0]) == "de"
-        assert str(translations[1]) == "ja"
-        assert str(translations[2]) == "de_DE"
+        assert str(translations[1]) == "de_DE"
+        assert str(translations[2]) == "ja"
 
 
 def test_list_translations_default_locale_exists():
@@ -103,7 +103,7 @@ def test_list_translations_default_locale_exists():
     b = babel.Babel(app, default_locale="de")
 
     with app.app_context():
-        translations = b.list_translations()
+        translations = sorted(b.list_translations(), key=str)
         assert len(translations) == 2
         assert str(translations[0]) == "de"
         assert str(translations[1]) == "ja"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,13 +38,13 @@ def test_multiple_directories():
     b.init_app(app)
 
     with app.test_request_context():
-        translations = b.list_translations()
+        translations = sorted(b.list_translations(), key=str)
 
         assert len(translations) == 4
         assert str(translations[0]) == "de"
-        assert str(translations[1]) == "ja"
-        assert str(translations[2]) == "de"
-        assert str(translations[3]) == "de_DE"
+        assert str(translations[1]) == "de"
+        assert str(translations[2]) == "de_DE"
+        assert str(translations[3]) == "ja"
 
         assert gettext("Hello %(name)s!", name="Peter") == "Hallo Peter!"
 


### PR DESCRIPTION
So the list_translations() method uses os.listdir() without any additional params. This can yield different results on different machines:
```python
# ...
                if any(x.endswith(".mo") for x in os.listdir(locale_dir)):
                    result.append(Locale.parse(folder))
# ...
```

For example:
```sh
$ python3 -python3 -c "print(__import__('os').listdir('./tests/translations'))"
['messages.pot', 'ja', 'de', 'fr'] # on my x64_64 machine
['fr', 'messages.pot', 'de', 'ja'] # on my loongarch64 machine
```

The documentation of list_translations() say nothing about translations ordering. So I've decided that it's error in tests hence this PR is changing them rather that list_translations() method.